### PR TITLE
logic-rx.html - html 출력 수정

### DIFF
--- a/part1/03.logic/logic-rx.html
+++ b/part1/03.logic/logic-rx.html
@@ -50,7 +50,8 @@ dt {
 			reduce((acc, user) => {
 				acc.push(makeHtml(user));
 				return acc;
-			}, [])
+			}, []),
+			map(htmlArr => htmlArr.join(""))
 		)
 		.subscribe(v => {
 			document.getElementById("users").innerHTML = v;


### PR DESCRIPTION
`logic.html`에 존재하던 `process` 함수가 없어지면서 `Array<string>`을 `string`으로 변환하는 과정이 사라졌습니다.

따라서 현재 Observable은 `Array<string>` 을 emit 하기 때문에, `string`을 emit 하도록 map 함수를 추가로 조합하였습니다.